### PR TITLE
Add fleet plugin analytics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-dotenv==1.0.0
 quart==0.18.4
 quart_cors==0.6.0
 Requests==2.29.0
+fleet-sdk=0.8.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ python-dotenv==1.0.0
 quart==0.18.4
 quart_cors==0.6.0
 Requests==2.29.0
-fleet-sdk=0.8.5
+fleet-sdk=0.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ python-dotenv==1.0.0
 quart==0.18.4
 quart_cors==0.6.0
 Requests==2.29.0
-fleet_sdk=0.5.4
+fleet_sdk==0.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ python-dotenv==1.0.0
 quart==0.18.4
 quart_cors==0.6.0
 Requests==2.29.0
-fleet-sdk=0.5.4
+fleet_sdk=0.5.4

--- a/src/app.py
+++ b/src/app.py
@@ -8,7 +8,7 @@ import quart_cors
 from utils.process import query_place_collection
 from hypercorn.config import Config
 from hypercorn.asyncio import serve
-from fleet_sdk import Tracker
+from fleet_sdk.Tracker import Tracker
 
 
 load_dotenv()

--- a/src/app.py
+++ b/src/app.py
@@ -20,10 +20,11 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 app = quart_cors.cors(Quart(__name__))
+#Enable Fleet Analytics
 tracker = Tracker("fleet-a56990fc-871d-4ab8-ae1f-502054d376c0", app=app)
 
 @app.post("/recommendations")
-@tracker.log_event
+@tracker.log_event #Instrument this endpoint
 async def recommendations():
     try:
         data = await request.get_json(force=True)

--- a/src/app.py
+++ b/src/app.py
@@ -21,7 +21,7 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 
 app = quart_cors.cors(Quart(__name__))
 #Enable Fleet Analytics
-tracker = Tracker("fleet-a56990fc-871d-4ab8-ae1f-502054d376c0", app=app)
+tracker = Tracker("Replace with actual fleet ID from usefleet.ai", app=app) # Replace with actual fleet ID
 
 @app.post("/recommendations")
 @tracker.log_event #Instrument this endpoint

--- a/src/app.py
+++ b/src/app.py
@@ -8,6 +8,7 @@ import quart_cors
 from utils.process import query_place_collection
 from hypercorn.config import Config
 from hypercorn.asyncio import serve
+from fleet_sdk import Tracker
 
 
 load_dotenv()
@@ -19,8 +20,10 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 app = quart_cors.cors(Quart(__name__))
+tracker = Tracker("fleet-a56990fc-871d-4ab8-ae1f-502054d376c0", app=app)
 
 @app.post("/recommendations")
+@tracker.log_event
 async def recommendations():
     try:
         data = await request.get_json(force=True)


### PR DESCRIPTION
This PR adds Fleet plugin analytics. Follow these steps to install:

1. Generate a new plugin ID by visiting [www.usefleet.ai](www.usefleet.ai). Follow the instructions there to create your new ID.

2. Once you have your ID, locate the `Tracker` line in your Python script (usually `main.py`) and replace the existing ID with your new one.

3. Then update your dependencies by running: pip install -r requirements.txt

Run your ChatGPT plugin and you should see analytic data being sent to your Fleet account!
